### PR TITLE
Add support for 'g' git alias

### DIFF
--- a/fzf-git.plugin.zsh
+++ b/fzf-git.plugin.zsh
@@ -7,7 +7,8 @@
 _fzf_complete_git() {
     ARGS="$@"
     is_in_git_repo || return
-    [[ $ARGS == 'git checkout'* || $ARGS == 'git co'* ]] && fzf_complete_branch "$ARGS"
+    [[ $ARGS == 'git checkout'* || $ARGS == 'git co'* || $ARGS == 'g co'* || $ARGS == 'g checkout'* ]] && \
+      fzf_complete_branch "$ARGS"
 }
 
 _fzf_complete_gco() {


### PR DESCRIPTION
Hi Hans,

I have `alias g=git` in my shell and the expansion doesn't work here as it's hard coded to look for `git`. I don't know if there is a better way to respect git aliases or not but here's my bootleg patch at least to make it work :)