### PR TITLE
Add support for 'g' git alias 

### DIFF
--- a/fzf-git.plugin.zsh
+++ b/fzf-git.plugin.zsh
@@ -1,13 +1,23 @@
 # Git completions powered by FZF
 #
-# Based on: 
+# Based on:
 # - https://github.com/junegunn/fzf/wiki/Examples-(completion)
 # - https://gist.github.com/junegunn/8b572b8d4b5eddd8b85e5f4d40f17236
 
 _fzf_complete_git() {
     ARGS="$@"
     is_in_git_repo || return
-    [[ $ARGS == 'git checkout'* || $ARGS == 'git co'* ]] && fzf_complete_branch "$ARGS"
+
+    [[ $ARGS == 'git checkout'* || $ARGS == 'git co'* ]] && \
+      fzf_complete_branch "$ARGS"
+}
+
+_fzf_complete_g() {
+    ARGS="$@"
+    is_in_git_repo || return
+
+    [[ $ARGS == 'g checkout'* || $ARGS == 'g co'* ]] && \
+      fzf_complete_branch "$ARGS"
 }
 
 _fzf_complete_gco() {
@@ -20,7 +30,7 @@ fzf_complete_branch() {
     grep -vw 'HEAD' | sort | \
     sed 's/^..//' | cut -d' ' -f1 | \
     sed 's|^\(\x1b\[[0-9;]*m\)remotes/\(.*\)|\1\2|' | \
-    _fzf_complete "--reverse --multi" "$@" 
+    _fzf_complete "--reverse --multi" "$@"
 }
 
 is_in_git_repo() {


### PR DESCRIPTION
@hschne Ok, this is working for real. Let me know if this is out of scope for your plugin/dangerous at all. I think it should be OK as it only looks at `g co` and `g checkout` for matches, so even if someone aliases `g` to something else, the likelihood of the second argument colliding is slim. If you disagree I'm happy to just use my own fork and call it a day. Thanks!